### PR TITLE
Don't return a map entry for key when bulk get hits an error

### DIFF
--- a/crud.go
+++ b/crud.go
@@ -248,8 +248,9 @@ func (bucket *lolrus) GetBulkRaw(keys []string) (map[string][]byte, error) {
 		value, _, err := bucket.GetRaw(key)
 		if err != nil {
 			errs = append(errs, err)
+		} else {
+			result[key] = value
 		}
-		result[key] = value
 	}
 
 	if hadError {


### PR DESCRIPTION
Aligns walrus with Couchbase Server SDK behaviour - details on #22.

Fixes #22.