### PR TITLE
Fix broken walrus tests

### DIFF
--- a/lolrus_test.go
+++ b/lolrus_test.go
@@ -66,9 +66,6 @@ func TestIncr(t *testing.T) {
 	count, err = bucket.Incr("count1", 0, 0, 0)
 	assertNoError(t, err, "Incr")
 	assert.Equals(t, count, uint64(110))
-
-	count, err = bucket.Incr("count2", 0, 0, -1)
-	assertTrue(t, err != nil, "Expected error from Incr")
 }
 
 // Spawns 1000 goroutines that 'simultaneously' use Incr to increment the same counter by 1.

--- a/persist_test.go
+++ b/persist_test.go
@@ -84,13 +84,13 @@ func TestNewPersistentBucket(t *testing.T) {
 	os.Remove("/tmp/pool-buckit.walrus")
 	bucket, err := GetBucket("walrus:/tmp", "pool", "buckit")
 	assertNoError(t, err, "NewPersistentBucket failed")
-	assert.Equals(t, bucket.(*WalrusBucket).path, "/tmp/pool-buckit.walrus")
-	bucket.(*WalrusBucket).Close()
+	assert.Equals(t, bucket.path, "/tmp/pool-buckit.walrus")
+	bucket.Close()
 
 	bucket, err = GetBucket("./temp", "default", "buckit")
 	assertNoError(t, err, "NewPersistentBucket failed")
-	assert.Equals(t, bucket.(*WalrusBucket).path, "temp/buckit.walrus")
-	bucket.(*WalrusBucket).Close()
+	assert.Equals(t, bucket.path, "temp/buckit.walrus")
+	bucket.Close()
 }
 
 func TestWriteWithPersist(t *testing.T) {
@@ -101,7 +101,7 @@ func TestWriteWithPersist(t *testing.T) {
 	assertNoError(t, bucket.Write("key1", 0, 0, []byte("value1"), sgbucket.Raw|sgbucket.Persist), "Write failed")
 
 	// Load the file into a new bucket to make sure the value got saved to disk:
-	bucket2, err := load(bucket.(*WalrusBucket).path)
+	bucket2, err := load(bucket.path)
 	value, _, err := bucket2.GetRaw("key1")
 	assertNoError(t, err, "Get failed")
 	assert.Equals(t, string(value), "value1")

--- a/tap_test.go
+++ b/tap_test.go
@@ -19,7 +19,7 @@ func TestBackfill(t *testing.T) {
 	assert.True(t, feed != nil)
 
 	event := <-feed.Events()
-	assert.Equals(t, event.Opcode, sgbucket.TapBeginBackfill)
+	assert.Equals(t, event.Opcode, sgbucket.FeedOpBeginBackfill)
 	results := map[string]string{}
 	for i := 0; i < 3; i++ {
 		event := <-feed.Events()
@@ -30,7 +30,7 @@ func TestBackfill(t *testing.T) {
 		"able": `"A"`, "baker": `"B"`, "charlie": `"C"`})
 
 	event = <-feed.Events()
-	assert.Equals(t, event.Opcode, sgbucket.TapEndBackfill)
+	assert.Equals(t, event.Opcode, sgbucket.FeedOpEndBackfill)
 
 	event, ok := <-feed.Events()
 	assert.False(t, ok)


### PR DESCRIPTION
go 1.11, sgbucket fixes, along w/ test that was passing an invalid parameter value to incr.