### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/crud.go
+++ b/crud.go
@@ -80,7 +80,7 @@ func NewBucket(bucketName string) *WalrusBucket {
 var buckets map[[3]string]*WalrusBucket
 var bucketsLock sync.Mutex
 
-// Returns a Walrus-based Bucket specific to the given (url, pool, bucketname) tuple.
+// GetBucket returns a Walrus-based Bucket specific to the given (url, pool, bucketname) tuple.
 // That is, passing the same parameters will return the same Bucket.
 //
 // If the urlStr has any of the forms below it will be considered a filesystem directory

--- a/tap.go
+++ b/tap.go
@@ -9,7 +9,7 @@ type tapFeedImpl struct {
 	events  *queue
 }
 
-// Starts a TAP feed on a client connection. The events can be read from the returned channel.
+// StartTapFeed starts a TAP feed on a client connection. The events can be read from the returned channel.
 // To stop receiving events, call Close() on the feed.
 func (bucket *WalrusBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	channel := make(chan sgbucket.FeedEvent, 10)

--- a/views.go
+++ b/views.go
@@ -87,7 +87,7 @@ func (bucket *WalrusBucket) _compileDesignDoc(docname string, design *sgbucket.D
 	return nil
 }
 
-// Validates a design document.
+// CheckDDoc validates a design document.
 func CheckDDoc(value interface{}) (*sgbucket.DesignDoc, error) {
 	source, err := json.Marshal(value)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?