### PR TITLE
CBG-1217 Close the DoneChan on FeedArgument when tap or dcp feed goroutines terminates

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -39,10 +39,7 @@ func (bucket *WalrusBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *e
 		bucket.lock.Unlock()
 	}
 
-	go func() {
-		defer close(args.DoneChan)
-		feed.run()
-	}()
+	go feed.run()
 
 	return feed, nil
 }

--- a/tap.go
+++ b/tap.go
@@ -53,9 +53,11 @@ func (bucket *WalrusBucket) StartDCPFeed(args sgbucket.FeedArguments, callback s
 	}
 
 	go func() {
-		defer close(args.DoneChan)
 		for event := range tapFeed.Events() {
 			callback(event)
+		}
+		if args.DoneChan != nil {
+			close(args.DoneChan)
 		}
 	}()
 	return nil

--- a/tap.go
+++ b/tap.go
@@ -39,7 +39,10 @@ func (bucket *WalrusBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *e
 		bucket.lock.Unlock()
 	}
 
-	go feed.run()
+	go func() {
+		defer close(args.DoneChan)
+		feed.run()
+	}()
 
 	return feed, nil
 }
@@ -53,6 +56,7 @@ func (bucket *WalrusBucket) StartDCPFeed(args sgbucket.FeedArguments, callback s
 	}
 
 	go func() {
+		defer close(args.DoneChan)
 		for event := range tapFeed.Events() {
 			callback(event)
 		}


### PR DESCRIPTION
Ensures goroutines that starts Tap and DCP feeds terminates gracefully by closing the done channel on feed arguments.
Dependency: https://github.com/couchbase/sg-bucket/pull/58/files
