### PR TITLE
Changes to support sg-bucket interface tweaks

### DIFF
--- a/collection_bucket.go
+++ b/collection_bucket.go
@@ -118,6 +118,8 @@ func (wh *CollectionBucket) CloseAndDelete() error {
 
 func (wh *CollectionBucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 	switch feature {
+	case sgbucket.BucketStoreFeatureCollections:
+		return true
 	case sgbucket.BucketStoreFeatureSubdocOperations:
 		return false
 	case sgbucket.BucketStoreFeatureXattrs:

--- a/collection_bucket.go
+++ b/collection_bucket.go
@@ -218,9 +218,7 @@ func (wh *CollectionBucket) StartDCPFeed(args sgbucket.FeedArguments, callback s
 	// coalesce doneChans
 	go func() {
 		for _, collection := range requestedCollections {
-			fmt.Printf("before collection done chan %v\n", collection.FQName.String())
 			<-doneChans[collection]
-			fmt.Printf("after collection done chan %v\n", collection.FQName.String())
 		}
 		close(doneChan)
 	}()

--- a/collection_bucket.go
+++ b/collection_bucket.go
@@ -55,6 +55,15 @@ type WalrusCollection struct {
 }
 
 var _ sgbucket.DataStore = &WalrusCollection{}
+var _ sgbucket.DataStoreName = &WalrusCollection{}
+
+func (wh *WalrusCollection) ScopeName() string {
+	return wh.FQName.ScopeName()
+}
+
+func (wh *WalrusCollection) CollectionName() string {
+	return wh.FQName.CollectionName()
+}
 
 func GetCollectionBucket(url, bucketName string) (*CollectionBucket, error) {
 

--- a/crud.go
+++ b/crud.go
@@ -61,6 +61,8 @@ type WalrusBucket struct {
 	walrusData
 }
 
+var _ sgbucket.BucketStore = &WalrusBucket{}
+
 // A document stored in a Bucket's .Docs map
 type walrusDoc struct {
 	Raw      []byte // Raw data content, or nil if deleted
@@ -151,6 +153,18 @@ func bucketURLToDir(urlStr string) (dir string) {
 		}
 	}
 	return
+}
+
+func (bucket *WalrusBucket) ListDataStores() ([]sgbucket.DataStoreName, error) {
+	return []sgbucket.DataStoreName{scopeAndCollection{defaultScopeName, defaultCollectionName}}, nil
+}
+
+func (bucket *WalrusBucket) DefaultDataStore() sgbucket.DataStore {
+	return bucket
+}
+
+func (bucket *WalrusBucket) NamedDataStore(name sgbucket.DataStoreName) sgbucket.DataStore {
+	panic("NamedDataStore not supported on WalrusBucket")
 }
 
 func (bucket *WalrusBucket) VBHash(docID string) uint32 {

--- a/crud.go
+++ b/crud.go
@@ -778,3 +778,10 @@ func (bucket *WalrusBucket) GetExpiry(k string) (expiry uint32, getMetaError err
 	// Walrus does not support expiry, and treats all expiry operations as a noop
 	return 0, errors.New("Walrus does not support document expiry")
 }
+
+func (bucket *WalrusBucket) Exists(k string) (ok bool, err error) {
+	bucket.lock.RLock()
+	defer bucket.lock.RUnlock()
+	_, exists := bucket.Docs[k]
+	return exists, nil
+}

--- a/crud.go
+++ b/crud.go
@@ -774,6 +774,21 @@ func (bucket *WalrusBucket) IsError(err error, errorType sgbucket.DataStoreError
 	}
 }
 
+func (bucket *WalrusBucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
+	switch feature {
+	case sgbucket.BucketStoreFeatureSubdocOperations:
+		return false
+	case sgbucket.BucketStoreFeatureXattrs:
+		return false
+	case sgbucket.BucketStoreFeatureN1ql:
+		return false
+	case sgbucket.BucketStoreFeatureCrc32cMacroExpansion:
+		return false
+	default:
+		return false
+	}
+}
+
 func (bucket *WalrusBucket) GetExpiry(k string) (expiry uint32, getMetaError error) {
 	// Walrus does not support expiry, and treats all expiry operations as a noop
 	return 0, errors.New("Walrus does not support document expiry")

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/couchbaselabs/walrus
 
 go 1.17
 
-replace (
-	github.com/couchbase/sg-bucket => /Users/adam.fraser/dev/sg-bucket
-)
 require (
 	github.com/couchbase/sg-bucket v0.0.0-20220906164713-c9afe94ac5c8
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/couchbaselabs/walrus
 
 go 1.17
 
+replace (
+	github.com/couchbase/sg-bucket => /Users/adam.fraser/dev/sg-bucket
+)
 require (
 	github.com/couchbase/sg-bucket v0.0.0-20220906164713-c9afe94ac5c8
 	github.com/google/uuid v1.3.0

--- a/tap.go
+++ b/tap.go
@@ -2,7 +2,6 @@ package walrus
 
 import (
 	"expvar"
-	"fmt"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -54,25 +53,18 @@ func (bucket *WalrusBucket) StartDCPFeed(args sgbucket.FeedArguments, callback s
 	}
 
 	go func() {
-		fmt.Printf("StartDCPFeed before event loop\n")
 	eventLoop:
 		for {
 			select {
 			case event := <-tapFeed.Events():
 				event.TimeReceived = time.Now()
-				fmt.Printf("StartDCPFeed event loop for key %s\n", event.Key)
 				callback(event)
 			case <-args.Terminator:
 				break eventLoop
 			}
 		}
-		fmt.Printf("StartDCPFeed after event loop\n")
 		if args.DoneChan != nil {
-			fmt.Printf("StartDCPFeed before DoneChan close\n")
 			close(args.DoneChan)
-			fmt.Printf("StartDCPFeed after DoneChan close\n")
-		} else {
-			fmt.Printf("DoneChan was nil\n")
 		}
 	}()
 	return nil
@@ -91,14 +83,11 @@ func (feed *tapFeedImpl) Close() error {
 	feed.bucket.lock.Lock()
 	defer feed.bucket.lock.Unlock()
 
-	fmt.Printf("tapFeedImpl.Close()\n")
-
 	for i, afeed := range feed.bucket.tapFeeds {
 		if afeed == feed {
 			feed.bucket.tapFeeds[i] = nil
 		}
 	}
-	fmt.Printf("tapFeedImpl.Close() closing events channel\n")
 	feed.events.close()
 	feed.bucket = nil
 	return nil

--- a/tap.go
+++ b/tap.go
@@ -3,6 +3,7 @@ package walrus
 import (
 	"expvar"
 	"fmt"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 )
@@ -55,6 +56,7 @@ func (bucket *WalrusBucket) StartDCPFeed(args sgbucket.FeedArguments, callback s
 	go func() {
 		fmt.Printf("StartDCPFeed before event loop\n")
 		for event := range tapFeed.Events() {
+			event.TimeReceived = time.Now()
 			fmt.Printf("StartDCPFeed event loop for key %s\n", event.Key)
 			callback(event)
 		}


### PR DESCRIPTION
Tweaks based on top of #70 for review

- Implement `Exists(k string) (bool, error)`
- Implement `ListDataStores`
- Implement `DynamicDataStoreBucket` with `CreateDataStore` and `DropDataStore`
- Tweak to take any `DataStoreName` implementation
- Implement `DataStoreName` for `scopeAndCollection`
- Rename `newScopeAndCollection` to `newValidScopeAndCollection` for clarity
