### PR TITLE
Update to ignore 0 cas values in cas value check

### DIFF
--- a/crud.go
+++ b/crud.go
@@ -98,11 +98,13 @@ var bucketsLock sync.Mutex
 //
 // If the urlStr has any of the forms below it will be considered a filesystem directory
 // path, and the bucket will use a persistent backing file in that directory.
-//		walrus:/foo/bar
-//		walrus:bar
-//		file:///foo/bar
-//		/foo/bar
-//		./bar
+//
+//	walrus:/foo/bar
+//	walrus:bar
+//	file:///foo/bar
+//	/foo/bar
+//	./bar
+//
 // The bucket's filename will be "bucketName.walrus", or if the poolName is not
 // "default", "poolName-bucketName.walrus".
 //
@@ -445,6 +447,9 @@ func (bucket *WalrusBucket) WriteSubDoc(k string, subdocKey string, cas uint64, 
 	casOut, err = bucket.Get(k, &fullDoc)
 	if err != nil && !errors.Is(err, bucket.missingError(k)) {
 		return 0, err
+	}
+	if cas != 0 && casOut != cas {
+		return 0, fmt.Errorf("error: cas mismatch: %d expected %d received. Unable to update document", cas, casOut)
 	}
 
 	// Set new subdoc value

--- a/lolrus_test.go
+++ b/lolrus_test.go
@@ -258,6 +258,46 @@ func TestGets(t *testing.T) {
 
 }
 
+func TestWriteSubDoc(t *testing.T) {
+	bucket := NewBucket("buckit")
+	defer bucket.Close()
+	var expectedCas uint64
+	expectedCas = 2
+
+	rawJson := []byte(`{
+        "walrus":{
+            "foo":"lol",
+            "bar":"baz"}
+        }`)
+
+	added, err := bucket.Add("key", 0, rawJson)
+	assert.NoError(t, err)
+	assert.True(t, added)
+
+	var fullDoc map[string]interface{}
+	cas, err := bucket.Get("key", &fullDoc)
+	assert.NoError(t, err)
+
+	// update json
+	rawJson = []byte(`{
+        "walrus":{
+            "foo":"lol1",
+            "bar":"baz"}
+        }`)
+	// test update using incorrect cas value
+	_, err = bucket.WriteSubDoc("key", "walrus", 10, rawJson)
+	assert.Error(t, err)
+
+	// test update using correct cas value
+	cas, err = bucket.WriteSubDoc("key", "walrus", cas, rawJson)
+	assert.Equal(t, expectedCas, cas)
+
+	// test update using 0 cas value
+	cas, err = bucket.WriteSubDoc("key", "walrus", 0, rawJson)
+	expectedCas = 3
+	assert.Equal(t, expectedCas, cas)
+}
+
 func TestWriteCas(t *testing.T) {
 
 	bucket := NewBucket("buckit")


### PR DESCRIPTION
After a PR was merged of mine a while back I didn't put a check in to ignore 0 cas values passed into the WriteSubDoc function. This PR rectifies that coupled with a test to test the functionality. 