### PR TITLE
Add persistence for CollectionBuckets

### DIFF
--- a/collection_bucket.go
+++ b/collection_bucket.go
@@ -342,7 +342,7 @@ func (wh *CollectionBucket) _createCollection(name scopeAndCollection) (sgbucket
 	}
 
 	// Prefix the name with the bucket to ensure cross-bucket isolation for persisted collections
-	bucketPrefixedName := wh.name + ":" + name.String()
+	bucketPrefixedName := wh.name + "." + name.String()
 	if wh.dir == "" {
 		dataStore.WalrusBucket = NewBucket(bucketPrefixedName)
 	} else {
@@ -386,7 +386,10 @@ func (wh *CollectionBucket) dropCollection(name scopeAndCollection) error {
 	}
 
 	collection := wh.collections[collectionID]
-	collection.CloseAndDelete()
+	err := collection.CloseAndDelete()
+	if err != nil {
+		return err
+	}
 
 	delete(wh.collections, collectionID)
 	delete(wh.collectionIDs, name)
@@ -409,7 +412,7 @@ func (sc scopeAndCollection) CollectionName() string {
 }
 
 func (sc scopeAndCollection) String() string {
-	return sc.scope + ":" + sc.collection
+	return sc.scope + "." + sc.collection
 }
 
 func (sc scopeAndCollection) isDefault() bool {

--- a/collection_bucket_test.go
+++ b/collection_bucket_test.go
@@ -184,3 +184,100 @@ func TestCollectionMutations(t *testing.T) {
 	assert.Equal(t, len(c1Keys), numDocs)
 	assert.Equal(t, len(c2Keys), numDocs)
 }
+
+func TestGetPersistentMultiCollectionBucket(t *testing.T) {
+
+	tmpdir := t.TempDir()
+
+	huddle, err := GetCollectionBucket(fmt.Sprintf("walrus:%s", tmpdir), "buckit")
+	assert.NoError(t, err)
+
+	//huddle := NewCollectionBucket("huddle1")
+	c1 := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	ok, err := c1.Add("doc1", 0, "c1_value")
+	require.True(t, ok)
+	require.NoError(t, err)
+	c2 := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	ok, err = c2.Add("doc1", 0, "c2_value")
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	var value interface{}
+	_, err = c1.Get("doc1", &value)
+	require.NoError(t, err)
+	assert.Equal(t, "c1_value", value)
+	_, err = c2.Get("doc1", &value)
+	require.NoError(t, err)
+	assert.Equal(t, "c2_value", value)
+
+	// reopen collection, verify retrieval
+	c1copy := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	_, err = c1copy.Get("doc1", &value)
+	require.NoError(t, err)
+	assert.Equal(t, "c1_value", value)
+
+	// Close collection bucket
+	huddle.Close()
+
+	// Reopen persisted collection bucket
+	loadedHuddle, loadedErr := GetCollectionBucket(fmt.Sprintf("walrus:%s", tmpdir), "buckit")
+	assert.NoError(t, loadedErr)
+
+	// validate contents
+	var loadedValue interface{}
+	c1Loaded := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	_, err = c1Loaded.Get("doc1", &loadedValue)
+	require.NoError(t, err)
+	assert.Equal(t, "c1_value", loadedValue)
+
+	// drop collection, should remove persisted value
+	err = loadedHuddle.DropDataStore(scopeAndCollection{"scope1", "collection1"})
+	require.NoError(t, err)
+
+	// reopen collection, verify that previous data is not present
+	newC1 := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	_, err = newC1.Get("doc1", &loadedValue)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &sgbucket.MissingError{}))
+
+	// verify that non-dropped collection (collection2) values are still present
+	c2Loaded := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	_, err = c2Loaded.Get("doc1", &loadedValue)
+	require.NoError(t, err)
+	assert.Equal(t, "c2_value", loadedValue)
+
+	// Close collection bucket
+	loadedHuddle.Close()
+
+	// Reopen persisted collection bucket again to ensure dropped collection is not present
+	reloadedHuddle, reloadedErr := GetCollectionBucket(fmt.Sprintf("walrus:%s", tmpdir), "buckit")
+	assert.NoError(t, reloadedErr)
+
+	// reopen dropped collection, verify that previous data is not present
+	var reloadedValue interface{}
+	reloadedC1 := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	_, err = reloadedC1.Get("doc1", &reloadedValue)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &sgbucket.MissingError{}))
+
+	// reopen non-dropped collection, verify that previous data is present
+	reloadedC2 := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	_, err = reloadedC2.Get("doc1", &reloadedValue)
+	require.NoError(t, err)
+	assert.Equal(t, "c2_value", reloadedValue)
+
+	// Close and Delete the bucket, should delete underlying collections
+	reloadedHuddle.CloseAndDelete()
+
+	// Attempt to reopen persisted collectionBucket
+	postDeleteHuddle, err := GetCollectionBucket(fmt.Sprintf("walrus:%s", tmpdir), "buckit")
+	assert.NoError(t, err)
+
+	var postDeleteValue interface{}
+	postDeleteC2 := postDeleteHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	_, err = postDeleteC2.Get("doc1", &postDeleteValue)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &sgbucket.MissingError{}))
+	postDeleteHuddle.CloseAndDelete()
+
+}

--- a/collection_bucket_test.go
+++ b/collection_bucket_test.go
@@ -193,11 +193,11 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	assert.NoError(t, err)
 
 	//huddle := NewCollectionBucket("huddle1")
-	c1 := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	c1, _ := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
 	ok, err := c1.Add("doc1", 0, "c1_value")
 	require.True(t, ok)
 	require.NoError(t, err)
-	c2 := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	c2, _ := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
 	ok, err = c2.Add("doc1", 0, "c2_value")
 	require.True(t, ok)
 	require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	assert.Equal(t, "c2_value", value)
 
 	// reopen collection, verify retrieval
-	c1copy := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	c1copy, _ := huddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
 	_, err = c1copy.Get("doc1", &value)
 	require.NoError(t, err)
 	assert.Equal(t, "c1_value", value)
@@ -225,7 +225,7 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 
 	// validate contents
 	var loadedValue interface{}
-	c1Loaded := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	c1Loaded, _ := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
 	_, err = c1Loaded.Get("doc1", &loadedValue)
 	require.NoError(t, err)
 	assert.Equal(t, "c1_value", loadedValue)
@@ -235,13 +235,13 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	require.NoError(t, err)
 
 	// reopen collection, verify that previous data is not present
-	newC1 := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	newC1, _ := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
 	_, err = newC1.Get("doc1", &loadedValue)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &sgbucket.MissingError{}))
 
 	// verify that non-dropped collection (collection2) values are still present
-	c2Loaded := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	c2Loaded, _ := loadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
 	_, err = c2Loaded.Get("doc1", &loadedValue)
 	require.NoError(t, err)
 	assert.Equal(t, "c2_value", loadedValue)
@@ -255,13 +255,13 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 
 	// reopen dropped collection, verify that previous data is not present
 	var reloadedValue interface{}
-	reloadedC1 := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
+	reloadedC1, _ := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection1"})
 	_, err = reloadedC1.Get("doc1", &reloadedValue)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &sgbucket.MissingError{}))
 
 	// reopen non-dropped collection, verify that previous data is present
-	reloadedC2 := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	reloadedC2, _ := reloadedHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
 	_, err = reloadedC2.Get("doc1", &reloadedValue)
 	require.NoError(t, err)
 	assert.Equal(t, "c2_value", reloadedValue)
@@ -274,7 +274,7 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	assert.NoError(t, err)
 
 	var postDeleteValue interface{}
-	postDeleteC2 := postDeleteHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
+	postDeleteC2, _ := postDeleteHuddle.NamedDataStore(scopeAndCollection{"scope1", "collection2"})
 	_, err = postDeleteC2.Get("doc1", &postDeleteValue)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &sgbucket.MissingError{}))

--- a/collection_bucket_test.go
+++ b/collection_bucket_test.go
@@ -267,7 +267,7 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	assert.Equal(t, "c2_value", reloadedValue)
 
 	// Close and Delete the bucket, should delete underlying collections
-	reloadedHuddle.CloseAndDelete()
+	require.NoError(t, reloadedHuddle.CloseAndDelete())
 
 	// Attempt to reopen persisted collectionBucket
 	postDeleteHuddle, err := GetCollectionBucket(fmt.Sprintf("walrus:%s", tmpdir), "buckit")
@@ -278,6 +278,6 @@ func TestGetPersistentMultiCollectionBucket(t *testing.T) {
 	_, err = postDeleteC2.Get("doc1", &postDeleteValue)
 	require.Error(t, err)
 	require.True(t, errors.As(err, &sgbucket.MissingError{}))
-	postDeleteHuddle.CloseAndDelete()
+	require.NoError(t, postDeleteHuddle.CloseAndDelete())
 
 }


### PR DESCRIPTION
If a directory is included in the bucket URL when calling GetCollectionBucket, it's used to persist the underlying collections.  Directory format is the same as used for the single-collection GetBucket.

Underlying collections are persisted using existing bucket persistence, with fully qualified walrus bucket naming (bucket:scope:collection).

Dropping a collection triggers CloseAndDelete on the associated persisted collection.

CollectionBucket.CloseAndDelete() calls CloseAndDelete all associated collections.